### PR TITLE
Use latest version of massa-sc-script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "assemblyscript": "^0.19.20",
     "json-as": "^0.2.6",
-    "massa-sc-scripts": "4.0.1",
+    "massa-sc-scripts": "4.0.2",
     "massa-sc-std": "3.1.2",
     "visitor-as": "^0.6.0"
   }


### PR DESCRIPTION
Add the possibility to define the runtime in the build command. Default is the stubbed runtime.